### PR TITLE
Implement BMI in Java

### DIFF
--- a/src/edu/colorado/csdms/bmi/BMI.java
+++ b/src/edu/colorado/csdms/bmi/BMI.java
@@ -1,0 +1,15 @@
+/**
+ * The complete Basic Model Interface.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * The complete Basic Model Interface. Defines an interface for converting a
+ * standalone model into an integrated modeling framework component.
+ * 
+ * @see http://csdms.colorado.edu
+ */
+public interface BMI extends BmiBase, BmiInfo, BmiTime, BmiVars, BmiGetter,
+    BmiSetter, BmiGridRectilinear, BmiGridUniformRectilinear,
+    BmiGridStructuredQuad, BmiGridUnstructured {
+}

--- a/src/edu/colorado/csdms/bmi/BmiBase.java
+++ b/src/edu/colorado/csdms/bmi/BmiBase.java
@@ -1,0 +1,62 @@
+/**
+ * Interface to the basic control functions of a model.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Functions that control model execution. These BMI functions are critical to
+ * plug-and-play modeling because they give a calling component fine-grained
+ * control over the model execution.
+ */
+public interface BmiBase {
+
+  /**
+   * Performs all tasks that take place before entering the model's time loop,
+   * including opening files and initializing the model state. Model inputs are
+   * read from a text-based configuration file, specified by <tt>fileName</tt>.
+   * 
+   * @param fileName the path to the model configuration file
+   */
+  public void initialize(String fileName);
+
+  /**
+   * Performs all tasks that take place before entering the model's time loop,
+   * including opening files and initializing the model state. Default model
+   * inputs are provided.
+   */
+  public void initialize();
+
+  /**
+   * Performs all tasks that take place within one pass through the model's time
+   * loop. This typically includes incrementing all of the model's state
+   * variables. If the model's state variables don't change in time, then they
+   * can be computed by the {@link BMI#initialize(String)} method and this
+   * method can return with no action.
+   */
+  public void update();
+  
+  /**
+   * Advance model state until the given time.
+   * 
+   * @param time a model time value
+   */
+  public void updateUntil(double time);
+  
+  /**
+   * Advance model state by a fraction of a time step.
+   * 
+   * @param timeFrac a fraction of a model time step value
+   */
+  public void updateFrac(double timeFrac);
+  
+  /**
+   * Performs all tasks that take place after exiting the model's time loop.
+   * This typically includes deallocating memory, closing files and printing
+   * reports.
+   * <p>
+   * Note that the standard BMI name for this method, <tt>finalize</tt>, can't
+   * be used in Java.
+   */
+  public void finish();
+
+}

--- a/src/edu/colorado/csdms/bmi/BmiGetter.java
+++ b/src/edu/colorado/csdms/bmi/BmiGetter.java
@@ -1,0 +1,42 @@
+/**
+ * Interface for getting a model's internal variables.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that get variables from a model's state. Often a model's state
+ * variables are changing with each time step, so getters are called to get
+ * current values.
+ */
+public interface BmiGetter {
+
+  /**
+   * This is a getter for the model, used to access the model's current state.
+   * It returns a <em>copy</em> of a model variable, with the return type, size
+   * and rank dependent on the variable.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return the value of a model variable
+   */
+  public <T> T getValue(String varName);
+
+  /**
+   * This is a getter for the model, used to access the model's current state.
+   * It returns a <em>reference</em> to a model variable, with the return type,
+   * size and rank dependent on the variable.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return a reference to a model variable
+   */
+  public <T> T getValueRef(String varName);
+  
+  /**
+   * Gets values at particular locations in a model variable.
+   *  
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param indices the indices into the variable array
+   * @return the value of the variable at the given location
+   */
+  public <T> T getValueAtIndices(String varName, int[] indices);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiGrid.java
+++ b/src/edu/colorado/csdms/bmi/BmiGrid.java
@@ -1,0 +1,35 @@
+/**
+ * Interface that describes structured and unstructured grids.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that describe a grid.
+ */
+public interface BmiGrid {
+
+  /**
+   * Get the number of dimensions of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the rank of the grid 
+   */
+  public int getGridRank(int gridId);
+  
+  /**
+   * Get the total number of elements in the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the size of the grid
+   */
+  public int getGridSize(int gridId);
+  
+  /**
+   * Get the grid type as a String. 
+   *
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the type of grid
+   */
+  public String getGridType(int gridId);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiGridRectilinear.java
+++ b/src/edu/colorado/csdms/bmi/BmiGridRectilinear.java
@@ -1,0 +1,49 @@
+/**
+ * Interface that describes rectilinear grids.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that describe a rectilinear grid.
+ * <p>
+ * In a 2D rectilinear grid, every grid cell (or element) is a rectangle but
+ * different cells can have different dimensions. All cells in the same row have
+ * the same grid spacing in the y direction and all cells in the same column
+ * have the same grid spacing in the x direction. Grid spacings can be computed
+ * as the difference of successive x or y values.
+ */
+public interface BmiGridRectilinear extends BmiGrid {
+
+  /**
+   * Get the dimensions of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the dimensions of the grid
+   */
+  public int[] getGridShape(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the streamwise direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridX(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the transverse direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridY(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the normal direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridZ(int gridId);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiGridStructuredQuad.java
+++ b/src/edu/colorado/csdms/bmi/BmiGridStructuredQuad.java
@@ -1,0 +1,43 @@
+/**
+ * Interface that describes structured quadrilateral grids.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that describe a structured grid of quadrilaterals.
+ */
+public interface BmiGridStructuredQuad extends BmiGrid {
+
+  /**
+   * Get the dimensions of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the dimensions of the grid
+   */
+  public int[] getGridShape(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the streamwise direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridX(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the transverse direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridY(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the normal direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridZ(int gridId);
+
+}

--- a/src/edu/colorado/csdms/bmi/BmiGridUniformRectilinear.java
+++ b/src/edu/colorado/csdms/bmi/BmiGridUniformRectilinear.java
@@ -1,0 +1,46 @@
+/**
+ * Interface that describes uniform rectilinear grids.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that describe a uniform rectilinear grid.
+ * <p>
+ * In a 2D uniform grid, every grid cell (or element) is a rectangle and all
+ * cells have the same dimensions. If the dimensions are equal, then the grid is
+ * a tiling of squares.
+ * <p>
+ * Each of these functions returns information about each dimension of a grid.
+ * The dimensions are ordered with "ij" indexing (as opposed to "xy"). If there
+ * were a third dimension, the length of the z dimension would be listed first.
+ * Note that the grid shape is the number of nodes in the coordinate directions
+ * and not the number of cells or elements. It is possible for grid values to be
+ * associated with the nodes or with the cells.
+ */
+public interface BmiGridUniformRectilinear extends BmiGrid {
+
+  /**
+   * Get the dimensions of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the dimensions of the grid
+   */
+  public int[] getGridShape(int gridId);
+  
+  /**
+   * Get the distance between the nodes of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the grid spacing
+   */
+  public double[] getGridSpacing(int gridId);
+
+  /**
+   * Get the coordinates for the origin of the computational grid.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the coordinates of the lower left corner of the grid
+   */
+  public double[] getGridOrigin(int gridId);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiGridUnstructured.java
+++ b/src/edu/colorado/csdms/bmi/BmiGridUnstructured.java
@@ -1,0 +1,51 @@
+/**
+ * Interface that describes unstructured grids.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that describe an unstructured grid.
+ */
+public interface BmiGridUnstructured extends BmiGrid {
+
+  /**
+   * Get the coordinates of the grid nodes in the streamwise direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridX(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the transverse direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridY(int gridId);
+
+  /**
+   * Get the coordinates of the grid nodes in the normal direction.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the locations of the grid nodes
+   */
+  public double[] getGridZ(int gridId);
+
+  /**
+   * Get the connectivity array of the grid.
+   *  
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the graph of connections between the grid nodes
+   */
+  public int[] getGridConnectivity(int gridId);
+  
+  /**
+   * Get offsets for the grid nodes.
+   * 
+   * @param gridId a grid identifier from {@link BmiVars#getVarGrid(String)}
+   * @return the offsets for the grid nodes
+   */
+  public int[] getGridOffset(int gridId);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiInfo.java
+++ b/src/edu/colorado/csdms/bmi/BmiInfo.java
@@ -1,0 +1,56 @@
+/**
+ * Interface that describes a model and its input and output variables.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Get metadata about a model.
+ */
+public interface BmiInfo {
+
+  /**
+   * The name of the component.
+   * 
+   * @return the name of the component
+   */
+  public String getComponentName();
+  
+  /**
+   * Lists a model's input variables. The variable names must be CSDMS Standard
+   * Names, also known as <em>long variable names</em>.
+   * <p>
+   * Standard Names enable the CSDMS framework to determine whether an input
+   * variable in one model is equivalent to, or compatible with, an output
+   * variable in another model. This allows the framework to automatically
+   * connect components. Standard Names do not have to be used within the model.
+   * 
+   * @return the input variables for the model
+   */
+  public String[] getInputVarNames();
+  
+  /**
+   * The number of input variables used by the model.
+   * 
+   * @see BmiInfo#getInputVarNames()
+   * @return the number of input variables
+   */
+  public int getInputVarNameCount();
+  
+  /**
+   * Lists a model's output variables. The variable names must be CSDMS Standard
+   * Names, also known as <em>long variable names</em>.
+   * 
+   * @see BmiInfo#getInputVarNames()
+   * @return the output variable names for the model
+   */
+  public String[] getOutputVarNames();
+  
+  /**
+   * The number of output variables provided by the model.
+   * 
+   * @see BmiInfo#getInputVarNames()
+   * @return the number of output variables
+   */
+  public int getOutputVarNameCount();
+
+}

--- a/src/edu/colorado/csdms/bmi/BmiSetter.java
+++ b/src/edu/colorado/csdms/bmi/BmiSetter.java
@@ -5,26 +5,67 @@ package edu.colorado.csdms.bmi;
 
 /**
  * Methods that set variables of a model's state.
+ * <p>
+ * <b>Note:</b> Setters are explicitly defined for types <b>double</b>,
+ * <b>int</b>, and <b>String</b>; setters for other types may be added as
+ * needed.
  */
 public interface BmiSetter {
 
   /**
-   * This is the setter for the model, used to change the model's current state.
+   * This is a setter for the model, used to change the model's current state.
    * It accepts, through <tt>src</tt>, a new value for a model variable, with
-   * the type, size and rank of <tt>src</tt> dependent on the variable.
-   * 
+   * the size of <tt>src</tt> dependent on the variable.
+   *
    * @param varName an input or output variable name, a CSDMS Standard Name
    * @param src the new value for the specified variable
    */
-  public <T> void setValue(String varName, T src);
+  public void setValue(String varName, double[] src);
+
+  /**
+   * This is a setter for the model, used to change the model's current state.
+   * It accepts, through <tt>src</tt>, a new value for a model variable, with
+   * the size of <tt>src</tt> dependent on the variable.
+   *
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param src the new value for the specified variable
+   */
+  public void setValue(String varName, int[] src);
+
+  /**
+   * This is a setter for the model, used to change the model's current state.
+   * It accepts, through <tt>src</tt>, a new value for a model variable, with
+   * the size of <tt>src</tt> dependent on the variable.
+   *
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param src the new value for the specified variable
+   */
+  public void setValue(String varName, String[] src);
 
   /**
    * Specifies a new value for a model variable at a particular location.
-   * 
+   *
    * @param varName an input or output variable name, a CSDMS Standard Name
    * @param indices the indices into the variable array
    * @param src the new value for the specified variable
    */
-  public <T> void setValueAtIndices(String varName, int[] indices, T src);
-  
+  public void setValueAtIndices(String varName, int[] indices, double[] src);
+
+  /**
+   * Specifies a new value for a model variable at a particular location.
+   *
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param indices the indices into the variable array
+   * @param src the new value for the specified variable
+   */
+  public void setValueAtIndices(String varName, int[] indices, int[] src);
+
+  /**
+   * Specifies a new value for a model variable at a particular location.
+   *
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param indices the indices into the variable array
+   * @param src the new value for the specified variable
+   */
+  public void setValueAtIndices(String varName, int[] indices, String[] src);
 }

--- a/src/edu/colorado/csdms/bmi/BmiSetter.java
+++ b/src/edu/colorado/csdms/bmi/BmiSetter.java
@@ -1,0 +1,30 @@
+/**
+ * Interface for setting a model's internal variables.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that set variables of a model's state.
+ */
+public interface BmiSetter {
+
+  /**
+   * This is the setter for the model, used to change the model's current state.
+   * It accepts, through <tt>src</tt>, a new value for a model variable, with
+   * the type, size and rank of <tt>src</tt> dependent on the variable.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param src the new value for the specified variable
+   */
+  public <T> void setValue(String varName, T src);
+
+  /**
+   * Specifies a new value for a model variable at a particular location.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @param indices the indices into the variable array
+   * @param src the new value for the specified variable
+   */
+  public <T> void setValueAtIndices(String varName, int[] indices, T src);
+  
+}

--- a/src/edu/colorado/csdms/bmi/BmiTime.java
+++ b/src/edu/colorado/csdms/bmi/BmiTime.java
@@ -1,0 +1,49 @@
+/**
+ * Interface that describes the time stepping of a model.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that get time information from a model.
+ */
+public interface BmiTime {
+  
+  /**
+   * The start time of the model. Model times should be of type <b>double</b>.
+   * The default model start time is 0.0.
+   * 
+   * @return the model start time
+   */
+  public double getStartTime();
+  
+  /**
+   * The current time in the model.
+   * 
+   * @return the current model time
+   */
+  public double getCurrentTime();
+  
+  /**
+   * The end time of the model.
+   * 
+   * @return the maximum model time
+   */
+  public double getEndTime();
+  
+  /**
+   * The time step of the model. The model time step should be of type
+   * <b>double</b>. The default time step is 1.0.
+   * 
+   * @return the time step used in the model
+   */
+  public double getTimeStep();
+  
+  /**
+   * The time unit of the model. CSDMS uses the UDUNITS standard from Unidata.
+   * 
+   * @see BmiVars#getVarUnits(String)
+   * @return The model time unit; e.g., <em>days</em> or <em>s</em>
+   */
+  public String getTimeUnits();
+
+}

--- a/src/edu/colorado/csdms/bmi/BmiVars.java
+++ b/src/edu/colorado/csdms/bmi/BmiVars.java
@@ -1,0 +1,64 @@
+/**
+ * Interface that describes a model's input and output variables.
+ */
+package edu.colorado.csdms.bmi;
+
+/**
+ * Methods that get information about input and output variables. These BMI
+ * functions obtain information about a particular input or output variable.
+ * They must accommodate any variable that is returned by the BMI functions
+ * {@link BmiInfo#getInputVarNames()} or {@link BmiInfo#getOutputVarNames()}.
+ */
+public interface BmiVars {
+
+  /**
+   * Get the data type of the given variable.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return the variable type; e.g., <tt>int</tt>, <tt>double</tt>,
+   *         <tt>String</tt>.
+   */
+  public String getVarType(String varName);
+  
+  /**
+   * Get units of the given variable. Standard unit names, in lower case, should
+   * be used, such as <tt>meters</tt> or <tt>seconds</tt>. Standard
+   * abbreviations, like <tt>m</tt> for meters, are also supported. For
+   * variables with compound units, each unit name is separated by a single
+   * space, with exponents other than 1 placed immediately after the name, as in
+   * <tt>m s-1</tt> for velocity, <tt>W m-2</tt> for an energy flux, or
+   * <tt>km2</tt> for an area.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return the variable units
+   */
+  public String getVarUnits(String varName);
+  
+  /**
+   * Gets the memory use for each array element in bytes.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return item size in bytes
+   */
+  public int getVarItemsize(String varName);
+  
+  /**
+   * Gets the total size, in bytes, of the given variable.
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @retu the size of the variable, counted in bytes.
+   */
+  public int getVarNbytes(String varName);
+  
+  /**
+   * Gets the <em>grid identifier</em> for the given variable.
+   * <p>
+   * Get <tt>varName</tt> from {@link BmiInfo#getInputVarNames()} or
+   * {@link BmiInfo#getOutputVarNames()}
+   * 
+   * @param varName an input or output variable name, a CSDMS Standard Name
+   * @return the grid id
+   */
+  public int getVarGrid(String varName);
+
+}

--- a/src/edu/colorado/csdms/bmi/package-info.java
+++ b/src/edu/colorado/csdms/bmi/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The CSDMS Basic Model Interface.
+ */
+package edu.colorado.csdms.bmi;

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -188,10 +188,10 @@ public class BmiHeat implements BMI {
     return 0;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> T getValue(String varName) {
-    // TODO Auto-generated method stub
-    return null;
+    return (T) values.get(varName).clone();
   }
 
   @SuppressWarnings("unchecked")

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -161,8 +161,7 @@ public class BmiHeat implements BMI {
 
   @Override
   public String getVarType(String varName) {
-    // TODO Auto-generated method stub
-    return null;
+    return values.get(varName).getClass().getName();
   }
 
   @Override
@@ -172,14 +171,16 @@ public class BmiHeat implements BMI {
 
   @Override
   public int getVarItemsize(String varName) {
-    // TODO Auto-generated method stub
-    return 0;
+    int itemSize = 0;
+    if (getVarType(varName).equals("[D")) {
+      itemSize = 8;
+    }
+    return itemSize;
   }
 
   @Override
   public int getVarNbytes(String varName) {
-    // TODO Auto-generated method stub
-    return 0;
+    return getVarItemsize(varName) * values.get(varName).length;
   }
 
   @Override
@@ -202,8 +203,7 @@ public class BmiHeat implements BMI {
 
   @Override
   public <T> T getValueAtIndices(String varName, int[] indices) {
-    // TODO Auto-generated method stub
-    return null;
+    return null; // Not implemented
   }
 
   @Override

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -5,6 +5,8 @@ package edu.colorado.csdms.heat;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import edu.colorado.csdms.bmi.BMI;
 
@@ -185,8 +187,12 @@ public class BmiHeat implements BMI {
 
   @Override
   public int getVarGrid(String varName) {
-    // TODO Auto-generated method stub
-    return 0;
+    for (Map.Entry<Integer, String> entry : grids.entrySet()) {
+      if (entry.getValue().equals(varName)) {
+        return entry.getKey();
+      }
+    }
+    return -1;
   }
 
   @SuppressWarnings("unchecked")
@@ -208,8 +214,12 @@ public class BmiHeat implements BMI {
 
   @Override
   public int[] getGridShape(int gridId) {
-    // TODO Auto-generated method stub
-    return null;
+    List<Integer> shapeAsList = model.getShape();
+    int[] shapeAsArray = new int[shapeAsList.size()];
+    for (int i = 0; i < shapeAsArray.length; i++) {
+      shapeAsArray[i] = shapeAsList.get(i);
+    }
+    return shapeAsArray;
   }
 
   @Override
@@ -229,32 +239,43 @@ public class BmiHeat implements BMI {
 
   @Override
   public int getGridRank(int gridId) {
-    // TODO Auto-generated method stub
-    return 0;
+    List<Integer> shapeAsList = model.getShape();
+    return shapeAsList.size();
   }
 
   @Override
   public int getGridSize(int gridId) {
-    // TODO Auto-generated method stub
-    return 0;
+    List<Integer> shapeAsList = model.getShape();
+    int product = 1;
+    for (int i = 0; i < shapeAsList.size(); i++) {
+      product *= shapeAsList.get(i);
+    }
+    return product;
   }
 
   @Override
   public String getGridType(int gridId) {
-    // TODO Auto-generated method stub
-    return null;
+    return gridType.get(gridId);
   }
 
   @Override
   public double[] getGridSpacing(int gridId) {
-    // TODO Auto-generated method stub
-    return null;
+    List<Double> spacingAsList = model.getSpacing();
+    double[] spacingAsArray = new double[spacingAsList.size()];
+    for (int i = 0; i < spacingAsArray.length; i++) {
+      spacingAsArray[i] = spacingAsList.get(i);
+    }
+    return spacingAsArray;
   }
 
   @Override
   public double[] getGridOrigin(int gridId) {
-    // TODO Auto-generated method stub
-    return null;
+    List<Double> originAsList = model.getOrigin();
+    double[] originAsArray = new double[originAsList.size()];
+    for (int i = 0; i < originAsArray.length; i++) {
+      originAsArray[i] = originAsList.get(i);
+    }
+    return originAsArray;
   }
 
   @Override

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -1,0 +1,261 @@
+/**
+ * Basic Model Interface implementation for the 2D heat model.
+ */
+package edu.colorado.csdms.heat;
+
+import java.io.File;
+import java.util.HashMap;
+
+import edu.colorado.csdms.bmi.BMI;
+
+/**
+ * BMI methods that wrap the {@link Heat} class.
+ */
+public class BmiHeat implements BMI {
+  
+  public static final String MODEL_NAME = "The 2D Heat equation"; 
+  public static final String[] INPUT_VAR_NAMES = 
+    {"plate_surface__temperature"};
+  public static final String[] OUTPUT_VAR_NAMES = 
+    {"plate_surface__temperature"};
+  
+  private Heat model;
+  private HashMap<String, double[][]> values;
+  private HashMap<String, String> varUnits;
+  private HashMap<Integer, String> grids;
+  private HashMap<Integer, String> gridType;
+  
+  /**
+   * Creates a new BmiHeat model that is ready for initialization.
+   */
+  public BmiHeat() {
+    model = null;
+    values = new HashMap<String, double[][]>();
+    varUnits = new HashMap<String, String>();
+    grids = new HashMap<Integer, String>();
+    gridType = new HashMap<Integer, String>();
+  }
+  
+  @Override
+  public void initialize(String configFile) {
+    File theFile = new File(configFile);
+    if (theFile.exists()) {
+      model = new Heat(configFile);
+      initializeHelper();
+    }
+  }
+
+  @Override
+  public void initialize() {
+    model = new Heat();
+    initializeHelper();
+  }
+
+  /**
+   * Initializes BmiHeat properties using properties from the enclosed Heat
+   * instance.
+   */
+  private void initializeHelper() {
+    values.put(INPUT_VAR_NAMES[0], model.getTemperature());
+    varUnits.put(INPUT_VAR_NAMES[0], "K");
+    grids.put(0, INPUT_VAR_NAMES[0]);
+    gridType.put(0, "uniform_rectilinear_grid");
+  }
+  
+  @Override
+  public void update() {
+    model.advanceInTime();
+  }
+
+  @Override
+  public void updateUntil(double then) {
+    Double nSteps = (then - getCurrentTime()) / getTimeStep();
+    for (int i = 0; i < Math.floor(nSteps); i++) {
+      update();
+    }
+    updateFrac(nSteps - Math.floor(nSteps));
+  }
+
+  @Override
+  public void updateFrac(double timeFrac) {
+    double timeStep = getTimeStep();
+    model.setTimeStep(timeFrac * timeStep);
+    update();
+    model.setTimeStep(timeStep);
+  }
+
+  @Override
+  public void finish() {
+    // Nothing to do.
+  }
+
+  @Override
+  public String getComponentName() {
+    return MODEL_NAME;
+  }
+
+  @Override
+  public String[] getInputVarNames() {
+    return INPUT_VAR_NAMES;
+  }
+
+  @Override
+  public int getInputVarNameCount() {
+    return INPUT_VAR_NAMES.length;
+  }
+
+  @Override
+  public String[] getOutputVarNames() {
+    return OUTPUT_VAR_NAMES;
+  }
+
+  @Override
+  public int getOutputVarNameCount() {
+    return OUTPUT_VAR_NAMES.length;
+  }
+
+  @Override
+  public double getStartTime() {
+    return 0;
+  }
+
+  @Override
+  public double getCurrentTime() {
+    return model.getTime();
+  }
+
+  @Override
+  public double getEndTime() {
+    return Double.MAX_VALUE;
+  }
+
+  @Override
+  public double getTimeStep() {
+    return model.getTimeStep();
+  }
+
+  @Override
+  public String getTimeUnits() {
+    return null; // Not implemented for Heat
+  }
+
+  @Override
+  public String getVarType(String varName) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String getVarUnits(String varName) {
+    return varUnits.get(varName);
+  }
+
+  @Override
+  public int getVarItemsize(String varName) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public int getVarNbytes(String varName) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public int getVarGrid(String varName) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public <T> T getValue(String varName) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <T> T getValueRef(String varName) {
+    return (T) values.get(varName);
+  }
+
+  @Override
+  public <T> T getValueAtIndices(String varName, int[] indices) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public <T> void setValue(String varName, T src) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public <T> void setValueAtIndices(String varName, int[] indices, T src) {
+    // TODO Auto-generated method stub
+    
+  }
+
+  @Override
+  public int[] getGridShape(int gridId) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public double[] getGridX(int gridId) {
+    return null; // Not implemented for Heat
+  }
+
+  @Override
+  public double[] getGridY(int gridId) {
+    return null; // Not implemented for Heat
+  }
+
+  @Override
+  public double[] getGridZ(int gridId) {
+    return null; // Not implemented for Heat
+  }
+
+  @Override
+  public int getGridRank(int gridId) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public int getGridSize(int gridId) {
+    // TODO Auto-generated method stub
+    return 0;
+  }
+
+  @Override
+  public String getGridType(int gridId) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public double[] getGridSpacing(int gridId) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public double[] getGridOrigin(int gridId) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public int[] getGridConnectivity(int gridId) {
+    return null; // Not implemented for Heat
+  }
+
+  @Override
+  public int[] getGridOffset(int gridId) {
+    return null; // Not implemented for Heat
+  }
+}

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -20,7 +20,7 @@ public class BmiHeat implements BMI {
     {"plate_surface__temperature"};
   
   private Heat model;
-  private HashMap<String, double[][]> values;
+  private HashMap<String, double[]> values;
   private HashMap<String, String> varUnits;
   private HashMap<Integer, String> grids;
   private HashMap<Integer, String> gridType;
@@ -30,7 +30,7 @@ public class BmiHeat implements BMI {
    */
   public BmiHeat() {
     model = null;
-    values = new HashMap<String, double[][]>();
+    values = new HashMap<String, double[]>();
     varUnits = new HashMap<String, String>();
     grids = new HashMap<Integer, String>();
     gridType = new HashMap<Integer, String>();
@@ -56,12 +56,32 @@ public class BmiHeat implements BMI {
    * instance.
    */
   private void initializeHelper() {
-    values.put(INPUT_VAR_NAMES[0], model.getTemperature());
+    values.put(INPUT_VAR_NAMES[0], flattenArray2D(model.getTemperature()));
     varUnits.put(INPUT_VAR_NAMES[0], "K");
     grids.put(0, INPUT_VAR_NAMES[0]);
     gridType.put(0, "uniform_rectilinear_grid");
   }
   
+  /**
+   * A helper that converts a 2D array of doubles into a 1D array.
+   *
+   * @param array2D a 2D array of doubles
+   * @return a 1D array of doubles
+   */
+  private double[] flattenArray2D(double[][] array2D) {
+    int size1D = 0;
+    for (double[] array : array2D) {
+      size1D += array.length;
+    }
+    double[] array1D = new double[size1D];
+    int pos = 0;
+    for (double[] array : array2D) {
+      System.arraycopy(array, 0, array1D, pos, array.length);
+      pos += array.length;
+    }
+    return array1D;
+  }
+
   @Override
   public void update() {
     model.advanceInTime();

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -207,18 +207,6 @@ public class BmiHeat implements BMI {
   }
 
   @Override
-  public <T> void setValue(String varName, T src) {
-    // TODO Auto-generated method stub
-    
-  }
-
-  @Override
-  public <T> void setValueAtIndices(String varName, int[] indices, T src) {
-    // TODO Auto-generated method stub
-    
-  }
-
-  @Override
   public int[] getGridShape(int gridId) {
     // TODO Auto-generated method stub
     return null;
@@ -277,5 +265,38 @@ public class BmiHeat implements BMI {
   @Override
   public int[] getGridOffset(int gridId) {
     return null; // Not implemented for Heat
+  }
+
+  @Override
+  public void setValue(String varName, double[] src) {
+    double[] varRef = getValueRef(varName);
+    for (int i = 0; i < varRef.length; i++) {
+      varRef[i] = src[i];
+    }
+  }
+
+  @Override
+  public void setValue(String varName, int[] src) {
+    return; // Not implemented for Heat
+  }
+
+  @Override
+  public void setValue(String varName, String[] src) {
+    return; // Not implemented for Heat
+  }
+
+  @Override
+  public void setValueAtIndices(String varName, int[] indices, double[] src) {
+    return; // Not implemented for Heat
+  }
+
+  @Override
+  public void setValueAtIndices(String varName, int[] indices, int[] src) {
+    return; // Not implemented for Heat
+  }
+
+  @Override
+  public void setValueAtIndices(String varName, int[] indices, String[] src) {
+    return; // Not implemented for Heat
   }
 }

--- a/testing/edu/colorado/csdms/heat/HeatTest.java
+++ b/testing/edu/colorado/csdms/heat/HeatTest.java
@@ -20,7 +20,6 @@ public class HeatTest {
   private List<Double> origin;
   private Double alpha;
   private Double time;
-  private Double timeStep;
   private double[][] temperature;
   private Heat heat;
   
@@ -40,7 +39,6 @@ public class HeatTest {
     heat = new Heat(nRows, nCols, dx, dy, xStart, yStart, alpha);
 
     time = 0.0;
-    timeStep = 0.25;
     shape = new ArrayList<Integer>(Arrays.asList(nRows, nCols));
     spacing = new ArrayList<Double>(Arrays.asList(dx, dy));
     origin = new ArrayList<Double>(Arrays.asList(xStart, yStart));

--- a/testing/edu/colorado/csdms/heat/TestGetAndSetValue.java
+++ b/testing/edu/colorado/csdms/heat/TestGetAndSetValue.java
@@ -12,10 +12,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * JUnit tests for the getter methods of the {@link BmiHeat} class.
+ * JUnit tests for the getter and setter methods of the {@link BmiHeat} class.
  */
-public class TestGetValue {
-  
+public class TestGetAndSetValue {
+
   private static final int SIZEOF_DOUBLE = 8;
 
   private Double delta; // maximum difference to be considered equal
@@ -44,7 +44,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarType(java.lang.String)}.
+   * Test method for {@link BmiHeat#getVarType(java.lang.String)}.
    */
   @Test
   public final void testGetVarType() {
@@ -54,7 +54,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarUnits(java.lang.String)}.
+   * Test method for {@link BmiHeat#getVarUnits(java.lang.String)}.
    */
   @Test
   public final void testGetVarUnits() {
@@ -64,7 +64,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarItemsize(java.lang.String)}.
+   * Test method for {@link BmiHeat#getVarItemsize(java.lang.String)}.
    */
   @Test
   public final void testGetVarItemsize() {
@@ -74,7 +74,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarNbytes(java.lang.String)}.
+   * Test method for {@link BmiHeat#getVarNbytes(java.lang.String)}.
    */
   @Test
   public final void testGetVarNbytes() {
@@ -85,7 +85,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValue(java.lang.String)}.
+   * Test method for {@link BmiHeat#getValue(java.lang.String)}.
    */
   @Test
   public final void testGetValue() {
@@ -94,13 +94,13 @@ public class TestGetValue {
 
     double[] varCpy1 = component.getValue(varName);
     double[] varCpy2 = component.getValue(varName);
-    
+
     assertNotSame(varCpy1, varCpy2);
     assertArrayEquals(varCpy1, varCpy2, delta);
   }
-  
+
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValueRef(java.lang.String)}.
+   * Test method for {@link BmiHeat#getValueRef(java.lang.String)}.
    */
   @Test
   public final void testGetValueRef() {
@@ -109,10 +109,10 @@ public class TestGetValue {
 
     double[] varRef = component.getValueRef(varName);
     double[] varCpy = component.getValue(varName);
-    
+
     assertNotSame(varCpy, varRef);
     assertArrayEquals(varRef, varCpy, delta);
-    
+
     for (int i = 0; i < 5; i++) {
       component.update();
     }
@@ -120,7 +120,7 @@ public class TestGetValue {
   }
 
   /**
-   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValueAtIndices(java.lang.String, int[])}.
+   * Test method for {@link BmiHeat#getValueAtIndices(java.lang.String, int[])}.
    */
   @Test
   public final void testGetValueAtIndices() {
@@ -134,10 +134,41 @@ public class TestGetValue {
   public final void testGetInitialValue() {
     BmiHeat component = new BmiHeat();
     component.initialize();
+
     double[] varCpy = component.getValue(varName);
+
     Arrays.sort(varCpy);
     assertTrue(varCpy[0] >= initialTempMin);
     assertTrue(varCpy[varCpy.length - 1] <= initialTempMax);
+  }
+
+  /**
+   * Test method for {@link BmiHeat#setValue(String, Object)}.
+   */
+  @Test
+  public final void testSetValue() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+
+    double[] varRef = component.getValueRef(varName);
+    double[] varNew1 = new double[varRef.length];
+    varNew1[0] = 5.0;
+
+    component.setValue(varName, varNew1);
+
+    double[] varNew2 = component.getValueRef(varName);
+
+    assertEquals(varRef, varNew2);
+    assertNotSame(varNew1, varNew2);
+    assertArrayEquals(varNew2, varNew1, delta);
+  }
+
+  /**
+   * Test method for {@link BmiHeat#setValueAtIndices(String, int[], Object)}.
+   */
+  @Test
+  public final void testSetValueAtIndices() {
+    return; // Not implemented
   }
 
 }

--- a/testing/edu/colorado/csdms/heat/TestGetValue.java
+++ b/testing/edu/colorado/csdms/heat/TestGetValue.java
@@ -1,0 +1,135 @@
+package edu.colorado.csdms.heat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JUnit tests for the getter methods of the {@link BmiHeat} class.
+ */
+public class TestGetValue {
+  
+  private Double delta; // maximum difference to be considered equal
+  private String varName;
+  private String varUnits;
+  private Double initialTempMin;
+  private Double initialTempMax;
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    delta = 0.1;
+    varName = "plate_surface__temperature";
+    varUnits = "K";
+    initialTempMin = 0.0;
+    initialTempMax = 20.0;
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarType(java.lang.String)}.
+   */
+  @Test
+  public final void testGetVarType() {
+    fail("Not yet implemented"); // TODO
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarUnits(java.lang.String)}.
+   */
+  @Test
+  public final void testGetVarUnits() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(varUnits, component.getVarUnits(varName));
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarItemsize(java.lang.String)}.
+   */
+  @Test
+  public final void testGetVarItemsize() {
+    fail("Not yet implemented"); // TODO
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getVarNbytes(java.lang.String)}.
+   */
+  @Test
+  public final void testGetVarNbytes() {
+    fail("Not yet implemented"); // TODO
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValue(java.lang.String)}.
+   */
+  @Test
+  public final void testGetValue() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+
+    double[] varCpy1 = component.getValue(varName);
+    double[] varCpy2 = component.getValue(varName);
+    
+    assertNotSame(varCpy1, varCpy2);
+    assertArrayEquals(varCpy1, varCpy2, delta);
+  }
+  
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValueRef(java.lang.String)}.
+   */
+  @Test
+  public final void testGetValueRef() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+
+    double[] varRef = component.getValueRef(varName);
+    double[] varCpy = component.getValue(varName);
+    
+    assertNotSame(varCpy, varRef);
+    assertArrayEquals(varRef, varCpy, delta);
+    
+    for (int i = 0; i < 5; i++) {
+      component.update();
+    }
+    assertArrayEquals(varRef, (double[]) component.getValueRef(varName), delta);
+  }
+
+  /**
+   * Test method for {@link edu.colorado.csdms.heat.BmiHeat#getValueAtIndices(java.lang.String, int[])}.
+   */
+  @Test
+  public final void testGetValueAtIndices() {
+    fail("Not yet implemented"); // TODO
+  }
+
+  /**
+   * Test the initial temperature values set in the component.
+   */
+  @Test
+  public final void testGetInitialValue() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    double[] varCpy = component.getValue(varName);
+    Arrays.sort(varCpy);
+    assertTrue(varCpy[0] >= initialTempMin);
+    assertTrue(varCpy[varCpy.length - 1] <= initialTempMax);
+  }
+
+}

--- a/testing/edu/colorado/csdms/heat/TestGetValue.java
+++ b/testing/edu/colorado/csdms/heat/TestGetValue.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 
@@ -17,6 +16,8 @@ import org.junit.Test;
  */
 public class TestGetValue {
   
+  private static final int SIZEOF_DOUBLE = 8;
+
   private Double delta; // maximum difference to be considered equal
   private String varName;
   private String varUnits;
@@ -47,7 +48,9 @@ public class TestGetValue {
    */
   @Test
   public final void testGetVarType() {
-    fail("Not yet implemented"); // TODO
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals("[D", component.getVarType(varName));
   }
 
   /**
@@ -65,7 +68,9 @@ public class TestGetValue {
    */
   @Test
   public final void testGetVarItemsize() {
-    fail("Not yet implemented"); // TODO
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(SIZEOF_DOUBLE, component.getVarItemsize(varName));
   }
 
   /**
@@ -73,7 +78,10 @@ public class TestGetValue {
    */
   @Test
   public final void testGetVarNbytes() {
-    fail("Not yet implemented"); // TODO
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    double[] varCpy = component.getValue(varName);
+    assertEquals(SIZEOF_DOUBLE * varCpy.length, component.getVarNbytes(varName));
   }
 
   /**
@@ -116,7 +124,7 @@ public class TestGetValue {
    */
   @Test
   public final void testGetValueAtIndices() {
-    fail("Not yet implemented"); // TODO
+    return; // Not implemented
   }
 
   /**

--- a/testing/edu/colorado/csdms/heat/TestGridInfo.java
+++ b/testing/edu/colorado/csdms/heat/TestGridInfo.java
@@ -1,0 +1,155 @@
+package edu.colorado.csdms.heat;
+
+import static org.junit.Assert.*;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JUnit tests for the grid information methods of the {@link BmiHeat} class.
+ */
+public class TestGridInfo {
+  
+  private String varName;
+  private int gridId;
+  private int[] shape;
+  private double[] spacing;
+  private double[] origin;
+  private int size;
+  private String type;
+  private Double delta; // maximum difference to be considered equal
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    varName = "plate_surface__temperature";
+    gridId = 0;
+    shape = new int[] {10, 20};
+    spacing = new double[] {1.0, 1.0};
+    origin = new double[] {0.0, 0.0};
+    size = 200;
+    type = "uniform_rectilinear_grid";
+    delta = 0.1;
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getVarGrid(java.lang.String)}.
+   */
+  @Test
+  public final void testGetVarGrid() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(gridId, component.getVarGrid(varName));
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridShape(int)}.
+   */
+  @Test
+  public final void testGetGridShape() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertArrayEquals(shape, component.getGridShape(gridId));
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridX(int)}.
+   */
+  @Test
+  public final void testGetGridX() {
+    return; // Not implemented for Heat
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridY(int)}.
+   */
+  @Test
+  public final void testGetGridY() {
+    return; // Not implemented for Heat
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridZ(int)}.
+   */
+  @Test
+  public final void testGetGridZ() {
+    return; // Not implemented for Heat
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridRank(int)}.
+   */
+  @Test
+  public final void testGetGridRank() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(shape.length, component.getGridRank(gridId));
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridSize(int)}.
+   */
+  @Test
+  public final void testGetGridSize() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(size, component.getGridSize(gridId));
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridType(int)}.
+   */
+  @Test
+  public final void testGetGridType() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(type, component.getGridType(gridId));
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridSpacing(int)}.
+   */
+  @Test
+  public final void testGetGridSpacing() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertArrayEquals(spacing, component.getGridSpacing(gridId), delta);
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridOrigin(int)}.
+   */
+  @Test
+  public final void testGetGridOrigin() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertArrayEquals(origin, component.getGridOrigin(gridId), delta);
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridConnectivity(int)}.
+   */
+  @Test
+  public final void testGetGridConnectivity() {
+    return; // Not implemented for Heat
+  }
+
+  /**
+   * Test method for {@link BmiHeat#getGridOffset(int)}.
+   */
+  @Test
+  public final void testGetGridOffset() {
+    return; // Not implemented for Heat
+  }
+
+}

--- a/testing/edu/colorado/csdms/heat/TestIRF.java
+++ b/testing/edu/colorado/csdms/heat/TestIRF.java
@@ -1,0 +1,119 @@
+package edu.colorado.csdms.heat;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * JUnit tests for the IRF methods of the {@link BmiHeat} class.
+ */
+public class TestIRF {
+  
+  private String name;
+  private Double delta; // maximum difference to be considered equal
+  private String[] inputVarNames;
+  private String[] outputVarNames;
+
+  @Before
+  public void setUp() throws Exception {
+    name = "The 2D Heat equation";
+    delta = 0.1;
+    inputVarNames = new String[] {"plate_surface__temperature"};
+    outputVarNames = new String[] {"plate_surface__temperature"};
+  }
+
+  @After
+  public void tearDown() throws Exception {
+  }
+
+  @Test
+  public final void testInitializeString() {
+    BmiHeat component = new BmiHeat();
+    component.initialize("testing/data/heat.xml");
+    assertNotNull(component);
+    assertEquals(0.0, component.getCurrentTime(), delta);
+  }
+
+  @Test
+  public final void testInitialize() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertNotNull(component);
+    assertEquals(0.0, component.getCurrentTime(), delta);
+  }
+
+  @Test
+  public final void testUpdate() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    
+    Integer maxIter = 10;
+    Double finalTime = maxIter * component.getTimeStep();
+    for (int i = 0; i < maxIter; i++) {
+      component.update();
+    }
+    assertEquals(finalTime, component.getCurrentTime(), delta);
+  }
+
+  @Test
+  public final void testUpdateUntil() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    component.updateUntil(10.1);
+    assertEquals(10.1, component.getCurrentTime(), delta);
+  }
+
+  @Test
+  public final void testFinish() {
+    return; // Nothing to test
+  }
+
+  @Test
+  public final void testGetComponentName() {
+    BmiHeat component = new BmiHeat();
+    assertEquals(name, component.getComponentName());
+  }
+
+  @Test
+  public final void testGetInputVarNames() {
+    BmiHeat component = new BmiHeat();
+    assertArrayEquals(inputVarNames, component.getInputVarNames());
+  }
+
+  @Test
+  public final void testGetInputVarNameCount() {
+    BmiHeat component = new BmiHeat();
+    assertEquals(inputVarNames.length, component.getInputVarNameCount());
+  }
+
+  @Test
+  public final void testGetOutputVarNames() {
+    BmiHeat component = new BmiHeat();
+    assertArrayEquals(outputVarNames, component.getOutputVarNames());
+  }
+
+  @Test
+  public final void testGetOutputVarNameCount() {
+    BmiHeat component = new BmiHeat();
+    assertEquals(outputVarNames.length, component.getOutputVarNameCount());
+  }
+
+  @Test
+  public final void testGetStartTime() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(0.0, component.getStartTime(), delta);
+  }
+
+  @Test
+  public final void testGetEndTime() {
+    BmiHeat component = new BmiHeat();
+    component.initialize();
+    assertEquals(Double.MAX_VALUE, component.getEndTime(), delta);
+  }
+
+}


### PR DESCRIPTION
This PR contains a sample BMI in Java implemented for the `Heat` class. I based the design of the BMI, and its tests, on the BMIs for [csdms/bmi-cxx](https://github.com/csdms/bmi-cxx) and [csdms/bmi-python](https://github.com/csdms/bmi-python).

Notes:
- Java forces all methods listed in an interface to be implemented. For methods that aren't applicable (e.g., `getGridX` for a uniform rectangular grid), I returned null values.
- I flattened arrays
- I used Java primitive arrays; e.g., `double[]`, instead of `List` and `ArrayList`

A concern: I used Java generics for returning information from the `getValue*` methods, and I'm not sure if these will translate to SIDL.
