### PR TITLE
Add Javadoc documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,11 @@ hs_err_pid*
 /bin/
 /build/
 
+# Javadoc
+/doc/
+
+# Eclipse project
 .project
+
+# Annoying MacOSX files
+.DS_Store

--- a/build.xml
+++ b/build.xml
@@ -5,6 +5,7 @@
 	<property name="test.data.dir" value="${test.src.dir}/data" />
 	<property name="build.dir" value="build" />
 	<property name="build.data.dir" value="${build.dir}/data" />
+   <property name="doc.dir" value="doc" />
 
 	<path id="classpath.base" />
 
@@ -55,9 +56,20 @@
 		<echo message="Tests done." />
 	</target>
 
+	<!-- Create javadoc documentation. -->
+	<target name="doc">
+		<javadoc packagenames="edu.colorado.csdms.*" sourcepath="${main.src.dir}"
+		    destdir="${doc.dir}" author="true" version="true" use="true"
+		    overview="${main.src.dir}/overview.html"
+		    windowtitle="CSDMS BMI-Java Documentation">
+		</javadoc>
+		<echo message="Docs done." />
+	</target>
+
 	<!-- Delete all built files. -->
 	<target name="clean">
 		<delete dir="${build.dir}" />
+		<delete dir="${doc.dir}" />
 		<echo message="Clean done." />
 	</target>
 </project>

--- a/src/edu/colorado/csdms/bmi/BMI.java
+++ b/src/edu/colorado/csdms/bmi/BMI.java
@@ -1,13 +1,14 @@
 /**
- * The complete Basic Model Interface.
+ * The complete Basic Model Interface (BMI) in Java.
  */
 package edu.colorado.csdms.bmi;
 
 /**
- * The complete Basic Model Interface. Defines an interface for converting a
- * standalone model into an integrated modeling framework component.
- * 
- * @see http://csdms.colorado.edu
+ * The complete Basic Model Interface (BMI). Defines an interface for converting
+ * a standalone model into an integrated modeling framework component.
+ * <p>
+ * See the <a href="http://csdms.colorado.edu">CSDMS</a> web page for more
+ * information about BMI.
  */
 public interface BMI extends BmiBase, BmiInfo, BmiTime, BmiVars, BmiGetter,
     BmiSetter, BmiGridRectilinear, BmiGridUniformRectilinear,

--- a/src/edu/colorado/csdms/bmi/BmiVars.java
+++ b/src/edu/colorado/csdms/bmi/BmiVars.java
@@ -46,7 +46,7 @@ public interface BmiVars {
    * Gets the total size, in bytes, of the given variable.
    * 
    * @param varName an input or output variable name, a CSDMS Standard Name
-   * @retu the size of the variable, counted in bytes.
+   * @return the size of the variable, counted in bytes.
    */
   public int getVarNbytes(String varName);
   

--- a/src/edu/colorado/csdms/heat/Heat.java
+++ b/src/edu/colorado/csdms/heat/Heat.java
@@ -141,10 +141,11 @@ public class Heat {
 
   /**
    * Clones a 2D double array.
-   *
+   * <p>
+   * See http://stackoverflow.com/a/1686523/1563298
+   * 
    * @param array a 2d array of type double
    * @return a clone of the input array
-   * @see http://stackoverflow.com/a/1686523/1563298
    */
   private double[][] cloneArray2D(double[][] array) {
     double [][] clone = new double[array.length][];

--- a/src/overview.html
+++ b/src/overview.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+   <head>
+      <title>CSDMS BMI-Java Documentation</title>
+   </head>
+   <body>
+      <h1>CSDMS BMI-Java Documentation</h1>
+      
+      <p>Java bindings for the Basic Model Interface.
+
+      <p>For more information on the Community Surface Dynamics Modeling System 
+      (CSDMS) and the Basic Model Interface (BMI),
+      please visit the CSDMS home page at
+      <a href="http://csdms.colorado.edu">http://csdms.colorado.edu</a>.
+   
+      <!-- documentation tags -->
+      @author Mark Piper / CSDMS
+      @version 0.1
+   </body>
+</html>


### PR DESCRIPTION
I added a target to the Ant buildfile to create Javadoc documentation for the project.

Build docs with:

```
$ ant doc
```

then view them by opening `docs/index.html` in a web browser.
