### PR TITLE
Updates to BMI

### DIFF
--- a/.bmi/api.yaml
+++ b/.bmi/api.yaml
@@ -5,4 +5,6 @@ package: edu.colorado.csdms.heat
 class: BmiHeat
 
 build:
-  - ant build
+  - ant dist
+  - install -d -m755 $CSDMS_PREFIX/lib
+  - install -m664 dist/bmi-java.jar $CSDMS_PREFIX/lib

--- a/.bmi/api.yaml
+++ b/.bmi/api.yaml
@@ -4,8 +4,5 @@ language: java
 package: edu.colorado.csdms.heat
 class: BmiHeat
 
-classpath:
-  - build
-
 build:
   - ant build

--- a/build.xml
+++ b/build.xml
@@ -5,7 +5,10 @@
 	<property name="test.data.dir" value="${test.src.dir}/data" />
 	<property name="build.dir" value="build" />
 	<property name="build.data.dir" value="${build.dir}/data" />
-   <property name="doc.dir" value="doc" />
+	<property name="dist.dir" value="dist" />
+	<property name="jarfile" value="${ant.project.name}.jar"/>
+	<property name="doc.dir" value="doc" />
+	<property name="main.class" value="edu.colorado.csdms.heat.BmiHeat"/>
 
 	<path id="classpath.base" />
 
@@ -56,6 +59,16 @@
 		<echo message="Tests done." />
 	</target>
 
+	<!-- Make a distributable jarfile. -->
+	<target name="dist" depends="build">
+		<mkdir dir="${dist.dir}"/>
+		<jar destfile="${dist.dir}/${jarfile}" basedir="${build.dir}">
+			<manifest>
+			   <attribute name="Main-Class" value="${main.class}"/>
+			</manifest>
+		</jar>
+	</target>
+
 	<!-- Create javadoc documentation. -->
 	<target name="doc">
 		<javadoc packagenames="edu.colorado.csdms.*" sourcepath="${main.src.dir}"
@@ -69,6 +82,7 @@
 	<!-- Delete all built files. -->
 	<target name="clean">
 		<delete dir="${build.dir}" />
+		<delete dir="${dist.dir}" />
 		<delete dir="${doc.dir}" />
 		<echo message="Clean done." />
 	</target>

--- a/src/edu/colorado/csdms/bmi/BmiBase.java
+++ b/src/edu/colorado/csdms/bmi/BmiBase.java
@@ -53,10 +53,7 @@ public interface BmiBase {
    * Performs all tasks that take place after exiting the model's time loop.
    * This typically includes deallocating memory, closing files and printing
    * reports.
-   * <p>
-   * Note that the standard BMI name for this method, <tt>finalize</tt>, can't
-   * be used in Java.
    */
-  public void finish();
+  public void finalize();
 
 }

--- a/src/edu/colorado/csdms/heat/BmiHeat.java
+++ b/src/edu/colorado/csdms/heat/BmiHeat.java
@@ -107,7 +107,7 @@ public class BmiHeat implements BMI {
   }
 
   @Override
-  public void finish() {
+  public void finalize() {
     // Nothing to do.
   }
 

--- a/testing/edu/colorado/csdms/heat/TestIRF.java
+++ b/testing/edu/colorado/csdms/heat/TestIRF.java
@@ -68,7 +68,7 @@ public class TestIRF {
   }
 
   @Test
-  public final void testFinish() {
+  public final void testFinalize() {
     return; // Nothing to test
   }
 


### PR DESCRIPTION
In this PR, I:
- Added a new target to the `ant` buildfile to create a jarfile for the application. Using the jarfile instead of a directory of class files should make it easier to work with `CLASSPATH`.
- Updated the install instructions in **api.yaml** -- I now build the jarfile and install it in the **lib/** directory. For precedence, this is where CCA toolchain programs install other Java jarfiles.
- Reverted BMI method name to `finalize`. The conflict with this method name occurs later, when the application gets wrapped by Babel.
